### PR TITLE
Display whitespace and window resize border

### DIFF
--- a/themes/pitch-black-color-theme.json
+++ b/themes/pitch-black-color-theme.json
@@ -14,6 +14,7 @@
     "sideBarTitle.foreground": "#d4d4d4",
     "sideBar.foreground": "#d4d4d4",
     "statusBar.foreground": "#ccc",
+    "editorWhitespace.foreground": "#202020",
 
     // Tabs
     "tab.activeForeground": "#fff",
@@ -67,7 +68,7 @@
 
     // Misc lines and rulers
     "editorRuler.foreground": "#222", // Enabled by "editor.rulers": [100],
-    "sideBar.border": "#000",
+    "sideBar.border": "#202020",
     "editorGroup.border": "#000",
     "editorIndentGuide.background": "#000", // Indent lines
     "editorIndentGuide.activeBackground": "#000", // Active indent line


### PR DESCRIPTION
Make whitespace visible (when enabled in the editor settings), currently they are black on black and only displayed when highlighted (cause the background then changes to blue)

Make the border of the filedrawer visible like the one of the Terminal, to be able to click and resize. This has an untended sideeffect: There appears a line behind "Incoming/Outgoing" in the git view.